### PR TITLE
Fixes zip_root default value, to correct issue #1 on github.com

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+Version 0.05
+	- Fixes zip_root default value coderef.
+
 Version 0.04
 	- Initial commit to github.com at https://github.com/mpfos/chartdb-perl.
 	- Adds POD documentation.

--- a/ChartDB.pm
+++ b/ChartDB.pm
@@ -18,11 +18,11 @@ use warnings;
 
 =head1 VERSION
 
-Version 0.04
+Version 0.05
 
 =cut
 
-our $VERSION = 0.04;
+our $VERSION = 0.05;
 
 use Carp;
 use Path::Tiny;
@@ -400,7 +400,7 @@ C<zip_root> is the chart database subdirectory for the zipped chart files.
 has 'zip_root' => (
     is      => 'ro',
     isa     => "Path::Tiny",
-    default => sub { Path::Tiny->cwd->('ZIP_ROOT') }
+    default => sub { Path::Tiny->cwd->child('ZIP_ROOT') }
 );
 
 =head2 C<failures>


### PR DESCRIPTION
ChartDB.pm Version 0.05

When constructing the zip_root attributes default value, the "child" sub
call was left off of "Path::Tiny->cwd->child(" preventing compile.

ISSUE:#1

Status: Fixed.
